### PR TITLE
add support for calendar plugin

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -585,6 +585,24 @@ a.tag {
   padding-right: unset;
 }
 
+/* Add support for [Calendar plugin](https://github.com/liamcain/obsidian-calendar-plugin) */
+#calendar-container {
+  --color-background-heading: transparent;
+
+  --color-background-day: transparent;
+  --color-background-day-empty: transparent;
+  --color-background-day-active: var(--background-nav-selected);
+  --color-background-day-hover: var(--background-nav-alt);
+
+  --color-dot: var(--text-nav);
+  --color-arrow: var(--text-nav);
+
+  --color-text-title: var(--text-faint);
+  --color-text-heading: var(--text-faint);
+  --color-text-day: var(--text-nav);
+  --color-text-today: var(--text-nav-selected);
+}
+
 
 /* 
 Try to support content in the navs... this is difficult because this theme is a 

--- a/obsidian.css
+++ b/obsidian.css
@@ -178,7 +178,7 @@
 }
 
 /* resize handle coloring */
-.workspace-leaf-resize-handle {;
+.workspace-leaf-resize-handle {
   background-color: transparent;
 }
 


### PR DESCRIPTION
"red-graphite" theme is my favorite theme for Obsidian. Latest public build of Obsidian (v0.9.10) added support for third-party plug-in support. Unfortunately, the **Light mode** of Obsidian by default doesn't work well with the [obsidian calendar plugin](https://github.com/liamcain/obsidian-calendar-plugin) in the right-sidebar. (screenshot copied at below). So I tweaked it a little bit.   
![image](https://user-images.githubusercontent.com/21694444/98429311-cb9ad700-205a-11eb-85f4-3cb587761f48.png)

After the fix included in this PR, it'll looks like this
![image](https://user-images.githubusercontent.com/21694444/98429286-b45be980-205a-11eb-979a-bb4f51297853.png)

p.s. 
My favorite plugins are "Obsidian Calendar" and "Editor Syntax Highlight". "red-graphite" theme Light mode 
