### PR TITLE
remove padding on inline code

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -389,7 +389,6 @@ div.markdown-preview-view {
 .markdown-preview-section code {
   background-color: var(--background-inline-code);
   border: 0px solid var(--border-inline-code);
-  padding: 4px 4px;
   font-weight: 600;
   color: var(--text-inline-code);
 }


### PR DESCRIPTION
Padding obscures the cursor in vim mode.
Unfortunately this can't be corrected with `obsidian.css` or css snippets as those are applied before the theme.

Current workaround is to edit theme directly in `vault/.obsidian/themes`.

### with padding
![Screen Shot 2021-02-19 at 10 44 24 AM](https://user-images.githubusercontent.com/453580/108526865-a3e51d00-729f-11eb-86f9-856864eb51c6.png)

### without padding
![Screen Shot 2021-02-19 at 10 44 46 AM](https://user-images.githubusercontent.com/453580/108526895-ac3d5800-729f-11eb-9760-abb88d5a9486.png)
