### PR TITLE
Set `--interactive-accent-hover` so it doesn't just turn to the default purple.

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -13,6 +13,7 @@
   --font-family-editor: Avenir, "Avenir Next", "Avenir Next Cyr", 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --font-family-preview: Avenir, "Avenir Next", "Avenir Next Cyr", 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --interactive-accent: rgb(203, 77, 73);
+  --interactive-accent-hover: rgb(151, 46, 43);
   --text-accent: rgb(203, 77, 73);
   --text-faint: rgb(150, 150, 150);
   --text-header: rgb(44, 44, 44);
@@ -38,6 +39,7 @@
   --font-family-editor: Avenir, "Avenir Next", "Avenir Next Cyr", 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --font-family-preview: Avenir, "Avenir Next", "Avenir Next Cyr", 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Microsoft YaHei Light", sans-serif;
   --interactive-accent: rgb(116, 190, 247);
+  --interactive-accent-hover: rgb(24, 147, 242);
   --text-accent: rgb(116, 190, 247);
   --text-faint: rgb(150, 150, 150);
   --text-header: rgb(198, 213, 224);


### PR DESCRIPTION
This theme is awesome, thank you so much for making it!

I noticed that there is no `--interactive-accent-hover` set, so it inherits the default purple:

![purple_hover](https://user-images.githubusercontent.com/772937/121930308-179bb180-ccf7-11eb-88f7-a9a6c0c28354.gif)